### PR TITLE
Fix build errors when building with DEBUG=1

### DIFF
--- a/src/sliding_puzzle.c
+++ b/src/sliding_puzzle.c
@@ -873,6 +873,10 @@ static void RotateTile(u8 rotDir)
         sprite->sOrientation++;
         sprite->sOrientation = sprite->sOrientation % ORIENTATION_MAX;
     }
+    else
+    {
+        return;
+    }
 
     StartSpriteAffineAnim(sprite, affineAnimation);
     sprite->sAnimating = TRUE;


### PR DESCRIPTION
When building with DEBUG=1, there is an error caused by `affineAnimation` potentially not being initialized before use. This change ensures that if `ROTATE_NONE` or some invalid value is passed it `RotateTile`, no animation is played.