### PR TITLE
Ported Shiny Starter Previews with Shiny Star in Preview

### DIFF
--- a/data/maps/NewBarkTown_Lab_hns/scripts.inc
+++ b/data/maps/NewBarkTown_Lab_hns/scripts.inc
@@ -234,7 +234,9 @@ NewBarkTown_Lab_EventScript_ChoseStarter::
 	hidemonpic
 	removeobject VAR_LAST_TALKED
 	msgbox NewBarkTown_Lab_Text_ChoseStarter, MSGBOX_DEFAULT
-	givemon PLAYER_STARTER_SPECIES, 5
+	call_if_eq VAR_STARTER_MON, 0, NewBarkTown_Lab_EventScript_GiveStarter_Chikorita
+	call_if_eq VAR_STARTER_MON, 1, NewBarkTown_Lab_EventScript_GiveStarter_Cyndaquil
+	call_if_eq VAR_STARTER_MON, 2, NewBarkTown_Lab_EventScript_GiveStarter_Totodile
 	setflag FLAG_SYS_POKEMON_GET
 	playfanfare MUS_OBTAIN_ITEM
 	bufferspeciesname STR_VAR_1, PLAYER_STARTER_SPECIES
@@ -247,6 +249,29 @@ NewBarkTown_Lab_EventScript_ChoseStarter::
 	callnative UpdateFollowingPokemon
 	release
 	end
+
+NewBarkTown_Lab_EventScript_GiveStarter_Chikorita::
+	call_if_unset FLAG_SHINY_STARTER_1, NewBarkTown_Lab_EventScript_GiveStarter_NotShiny
+	call_if_set FLAG_SHINY_STARTER_1, NewBarkTown_Lab_EventScript_GiveStarter_Shiny
+	return
+
+NewBarkTown_Lab_EventScript_GiveStarter_Cyndaquil::
+	call_if_unset FLAG_SHINY_STARTER_2, NewBarkTown_Lab_EventScript_GiveStarter_NotShiny
+	call_if_set FLAG_SHINY_STARTER_2, NewBarkTown_Lab_EventScript_GiveStarter_Shiny
+	return
+
+NewBarkTown_Lab_EventScript_GiveStarter_Totodile::
+	call_if_unset FLAG_SHINY_STARTER_3, NewBarkTown_Lab_EventScript_GiveStarter_NotShiny
+	call_if_set FLAG_SHINY_STARTER_3, NewBarkTown_Lab_EventScript_GiveStarter_Shiny
+	return
+
+NewBarkTown_Lab_EventScript_GiveStarter_NotShiny::
+	givemon PLAYER_STARTER_SPECIES, 5, ITEM_NONE, BALL_POKE, NATURE_RANDOM, NUM_ABILITY_PERSONALITY, MON_GENDER_RANDOM, 0, 0, 0, 0, 0, 0, USE_RANDOM_IVS, USE_RANDOM_IVS, USE_RANDOM_IVS, USE_RANDOM_IVS, USE_RANDOM_IVS, USE_RANDOM_IVS, MOVE_DEFAULT, MOVE_DEFAULT, MOVE_DEFAULT, MOVE_DEFAULT, SHINY_MODE_NEVER
+	return
+
+NewBarkTown_Lab_EventScript_GiveStarter_Shiny::
+	givemon PLAYER_STARTER_SPECIES, 5, ITEM_NONE, BALL_POKE, NATURE_RANDOM, NUM_ABILITY_PERSONALITY, MON_GENDER_RANDOM, 0, 0, 0, 0, 0, 0, USE_RANDOM_IVS, USE_RANDOM_IVS, USE_RANDOM_IVS, USE_RANDOM_IVS, USE_RANDOM_IVS, USE_RANDOM_IVS, MOVE_DEFAULT, MOVE_DEFAULT, MOVE_DEFAULT, MOVE_DEFAULT, SHINY_MODE_ALWAYS	
+	return
 
 NewBarkTown_Lab_EventScript_NicknameStarter::
 	setvar VAR_0x8004, 0

--- a/include/constants/flags_hns.h
+++ b/include/constants/flags_hns.h
@@ -1,6 +1,14 @@
 #ifndef GUARD_CONSTANTS_FLAGS_HNS_H
 #define GUARD_CONSTANTS_FLAGS_HNS_H
 
+// Temp Flag Aliases
+#define FLAG_STARTER_PREVIEW_CHECKED_1  FLAG_TEMP_1
+#define FLAG_STARTER_PREVIEW_CHECKED_2  FLAG_TEMP_2
+#define FLAG_STARTER_PREVIEW_CHECKED_3  FLAG_TEMP_3
+#define FLAG_SHINY_STARTER_1    FLAG_TEMP_4
+#define FLAG_SHINY_STARTER_2    FLAG_TEMP_5
+#define FLAG_SHINY_STARTER_3    FLAG_TEMP_6
+
 // Content flags (0x22 – 0x4FF)
 
 // Hide Pokemon
@@ -832,7 +840,7 @@
 #define FLAG_HIDE_ICEPATH_B2F_BOULDER4                              0x2FA
 #define FLAG_LATIOS_OR_LATIAS_ROAMING                              0x2FB
 #define FLAG_HIDE_VERMILION_STEVEN                              0x2FC
-#define FLAG_MOM_HAS_GIFT                              0x2FD
+#define FLAG_MOM_HAS_GIFT                           0x2FD
 #define FLAG_UNUSED_30                              0x2FE
 #define FLAG_UNUSED_31                              0x2FF
 #define FLAG_UNUSED_32                              0x300

--- a/include/field_effect.h
+++ b/include/field_effect.h
@@ -51,6 +51,7 @@ void SpriteCB_AshLaunch(struct Sprite *sprite);
 void MultiplyPaletteRGBComponents(u16 i, u8 r, u8 g, u8 b);
 void FreeResourcesAndDestroySprite(struct Sprite *sprite, u8 spriteId);
 u8 CreateMonSprite_PicBox(u16 species, s16 x, s16 y, u8 subpriority);
+u8 CreateShinyMonSprite_PicBox(u16 species, s16 x, s16 y, u8 subpriority);
 void StartEscapeRopeFieldEffect(void);
 void FieldEffectFreeGraphicsResources(struct Sprite *sprite);
 bool8 IsRockClimbActive(void);

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -736,6 +736,7 @@ extern const u32 sExpCandyExperienceTable[];
 extern const struct AbilityInfo gAbilitiesInfo[];
 extern const struct NatureInfo gNaturesInfo[];
 
+u32 GetShinyOdds(void);
 void ZeroBoxMonData(struct BoxPokemon *boxMon);
 void ZeroMonData(struct Pokemon *mon);
 void ZeroPlayerPartyMons(void);

--- a/include/script_menu.h
+++ b/include/script_menu.h
@@ -38,6 +38,7 @@ void DrawMultichoiceMenuInternal(u8 left, u8 top, u8 multichoiceId, bool8 ignore
 bool8 ScriptMenu_YesNo(u8 left, u8 top);
 bool8 ScriptMenu_MultichoiceGrid(u8 left, u8 top, u8 multichoiceId, bool8 ignoreBPress, u8 columnCount);
 bool8 ScriptMenu_ShowPokemonPic(u16 species, u8 x, u8 y);
+bool8 ScriptMenu_ShowShinyPokemonPic(u16 species, u8 x, u8 y);
 bool8 (*ScriptMenu_HidePokemonPic(void))(void);
 int ConvertPixelWidthToTileWidth(int width);
 u8 CreateWindowFromRect(u8 x, u8 y, u8 width, u8 height);

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -1072,6 +1072,16 @@ u8 CreateMonSprite_PicBox(u16 species, s16 x, s16 y, u8 subpriority)
         return spriteId;
 }
 
+u8 CreateShinyMonSprite_PicBox(u16 species, s16 x, s16 y, u8 subpriority)
+{
+    s32 spriteId = CreateMonPicSprite(species, TRUE, 0x8000, TRUE, x, y, 0, species);
+    PreservePaletteInWeather(IndexOfSpritePaletteTag(species) + 0x10);
+    if (spriteId == 0xFFFF)
+        return MAX_SPRITES;
+    else
+        return spriteId;
+}
+
 u8 CreateMonSprite_FieldMove(u16 species, bool8 isShiny, u32 personality, s16 x, s16 y, u8 subpriority)
 {
     u16 spriteId = CreateMonPicSprite(species, isShiny, personality, TRUE, x, y, 0, species);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -82,7 +82,7 @@ extern u16 gSpecialVar_ItemId;
 
 static const u32 sShinyOddsTable[] = { 8, 16, 32, 64, 128 };
 
-static u32 GetShinyOdds(void)
+u32 GetShinyOdds(void)
 {
     if (gSaveBlock3Ptr != NULL)
     {

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2632,28 +2632,99 @@ bool8 ScrCmd_showmonpic(struct ScriptContext *ctx)
     u16 species = VarGet(varId);
     u8 x = ScriptReadByte(ctx);
     u8 y = ScriptReadByte(ctx);
+    bool8 shinyStarter = FALSE;
 
     Script_RequestEffects(SCREFF_V1 | SCREFF_HARDWARE);
 
-#if RANDOMIZER_AVAILABLE
-    if (RandomizerFeatureEnabled(RANDOMIZE_STARTER_AND_GIFT_MON) && !FlagGet(FLAG_SYS_POKEMON_GET))
+    // If we have not gotten a pokemon yet, assume this is the starter preview
+    if (!FlagGet(FLAG_SYS_POKEMON_GET))
     {
-        species = RandomizeMon(RANDOMIZER_REASON_STARTER_AND_GIFT_MON, GetRandomizerOption(RANDOMIZER_OPTION_SPECIES_MODE), GetRandomizerSeed() ^ species, species);
-        if (species == SPECIES_TOGEPI)
-            species = SPECIES_CLEFFA;
-        if (varId >= VARS_START)
-            VarSet(varId, species);
-    }
-#endif
+        u8 starter = VarGet(VAR_STARTER_MON);
 
-    if (IsOneTypeChallengeActive() && !FlagGet(FLAG_SYS_POKEMON_GET))
-    {
-        species = GetStarterPokemon(VarGet(VAR_STARTER_MON));
-        if (varId >= VARS_START)
-            VarSet(varId, species);
+        u32 flagPreviewChecked = 0;
+        u32 flagShinyPreview = 0;
+
+        if (starter == 0)
+        {
+            flagPreviewChecked = FLAG_STARTER_PREVIEW_CHECKED_1;
+            flagShinyPreview = FLAG_SHINY_STARTER_1;
+        }
+        else if (starter == 1)
+        {
+            flagPreviewChecked = FLAG_STARTER_PREVIEW_CHECKED_2;
+            flagShinyPreview = FLAG_SHINY_STARTER_2;
+        }
+        else if (starter == 2)
+        {
+            flagPreviewChecked = FLAG_STARTER_PREVIEW_CHECKED_3;
+            flagShinyPreview = FLAG_SHINY_STARTER_3;
+        }
+
+        #ifndef NDEBUG
+            MgbaPrintf(MGBA_LOG_DEBUG, "******** Possible Temp Flags: %x, %x, %x ********", FLAG_TEMP_1, FLAG_TEMP_2, FLAG_TEMP_3);
+            MgbaPrintf(MGBA_LOG_DEBUG, "******** Possible Shiny Starter Flags: %x, %x, %x ********", FLAG_SHINY_STARTER_1, FLAG_SHINY_STARTER_2, FLAG_SHINY_STARTER_3);
+            MgbaPrintf(MGBA_LOG_DEBUG, "******** Actual Temp and Shiny Flags: %x, %x ********", flagPreviewChecked, flagShinyPreview);
+        #endif
+
+        // if FLAG_TEMP_X not set for this starter preview, roll for shininess,
+        // then set FLAG_TEMP_X to prevent re-rolls
+        if (!FlagGet(flagPreviewChecked))
+        {
+            #ifndef NDEBUG
+                MgbaPrintf(MGBA_LOG_DEBUG, "\n******** Rolling Starter Preview Shininess ********");
+                MgbaPrintf(MGBA_LOG_DEBUG, "******** Flag Values Before: %d, %d ********", FlagGet(flagPreviewChecked), FlagGet(flagShinyPreview));
+            #endif
+
+            u32 value = READ_OTID_FROM_SAVE;
+            u32 shinyPersonality = Random32();
+
+            // this is technically unnecessary right now, but will replace GetShinyOdds in terms of implementing user-defined shiny odds
+            u32 totalRerolls = 0;
+            if (CheckBagHasItem(ITEM_SHINY_CHARM, 1))
+                totalRerolls += I_SHINY_CHARM_ADDITIONAL_ROLLS;
+            
+            while (GET_SHINY_VALUE(value, shinyPersonality) >= GetShinyOdds() && totalRerolls > 0)
+            {
+                shinyPersonality = Random32();
+                totalRerolls--;
+            }
+
+            if (GET_SHINY_VALUE(value, shinyPersonality) < GetShinyOdds())
+                FlagSet(flagShinyPreview);
+
+            FlagSet(flagPreviewChecked);
+        }
+
+        shinyStarter = FlagGet(flagShinyPreview);
+
+        #ifndef NDEBUG
+            MgbaPrintf(MGBA_LOG_DEBUG, "******** Flag Values: %d, %d ********", FlagGet(flagPreviewChecked), FlagGet(flagShinyPreview));
+            MgbaPrintf(MGBA_LOG_DEBUG, "******** Preview Should be Shiny: %d ********", shinyStarter);
+        #endif
+
+        #if RANDOMIZER_AVAILABLE
+        if (RandomizerFeatureEnabled(RANDOMIZE_STARTER_AND_GIFT_MON))
+        {
+            species = RandomizeMon(RANDOMIZER_REASON_STARTER_AND_GIFT_MON, GetRandomizerOption(RANDOMIZER_OPTION_SPECIES_MODE), GetRandomizerSeed() ^ species, species);
+            if (species == SPECIES_TOGEPI)
+                species = SPECIES_CLEFFA;
+            if (varId >= VARS_START)
+                VarSet(varId, species);
+        }
+        #endif
+
+        if (IsOneTypeChallengeActive())
+        {
+            species = GetStarterPokemon(VarGet(VAR_STARTER_MON));
+            if (varId >= VARS_START)
+                VarSet(varId, species);
+        }
     }
 
-    ScriptMenu_ShowPokemonPic(species, x, y);
+    if (shinyStarter)
+        ScriptMenu_ShowShinyPokemonPic(species, x, y);
+    else
+        ScriptMenu_ShowPokemonPic(species, x, y);
     return FALSE;
 }
 

--- a/src/script_menu.c
+++ b/src/script_menu.c
@@ -17,6 +17,8 @@
 #include "malloc.h"
 #include "util.h"
 #include "item_icon.h"
+#include "sprite.h"
+#include "decompress.h"
 #include "constants/field_specials.h"
 #include "constants/items.h"
 #include "constants/script_menu.h"
@@ -24,6 +26,51 @@
 #include "constants/songs.h"
 
 #include "data/script_menu.h"
+
+// Shiny star indicator graphics and tags
+#define GFXTAG_SHINY_STAR_PREVIEW 5000
+#define PALTAG_SHINY_STAR_PREVIEW 5000
+
+static const u32 sShinyStarTiles[] = INCBIN_U32("graphics/summary_screen/shiny_icon.4bpp.lz");
+static const u16 sShinyStarPal[] = INCBIN_U16("graphics/summary_screen/heart.gbapal");
+
+static const struct OamData sOam_ShinyStarIcon =
+{
+    .y = 0,
+    .affineMode = ST_OAM_AFFINE_OFF,
+    .objMode = ST_OAM_OBJ_NORMAL,
+    .mosaic = FALSE,
+    .bpp = ST_OAM_4BPP,
+    .shape = SPRITE_SHAPE(8x8),
+    .x = 0,
+    .matrixNum = 0,
+    .size = SPRITE_SIZE(8x8),
+    .tileNum = 0,
+    .priority = 0,
+    .paletteNum = 0,
+};
+
+static const union AnimCmd sAnim_ShinyStarIcon[] =
+{
+    ANIMCMD_FRAME(0, 0),
+    ANIMCMD_END,
+};
+
+static const union AnimCmd *const sAnims_ShinyStarIcon[] =
+{
+    sAnim_ShinyStarIcon
+};
+
+static const struct SpriteTemplate sSpriteTemplate_ShinyStarIcon =
+{
+    .tileTag = GFXTAG_SHINY_STAR_PREVIEW,
+    .paletteTag = PALTAG_SHINY_STAR_PREVIEW,
+    .oam = &sOam_ShinyStarIcon,
+    .anims = sAnims_ShinyStarIcon,
+    .images = NULL,
+    .affineAnims = gDummySpriteAffineAnimTable,
+    .callback = SpriteCallbackDummy
+};
 
 struct DynamicListMenuEventArgs
 {
@@ -944,6 +991,7 @@ void GetLilycoveSSTidalSelection(void)
 #define tWindowX     data[3]
 #define tWindowY     data[4]
 #define tWindowId    data[5]
+#define tShinyStarSpriteId data[6]
 
 static void Task_PokemonPicWindow(u8 taskId)
 {
@@ -959,6 +1007,13 @@ static void Task_PokemonPicWindow(u8 taskId)
         break;
     case 2:
         FreeResourcesAndDestroySprite(&gSprites[task->tMonSpriteId], task->tMonSpriteId);
+        // Destroy shiny star sprite if it exists
+        if (task->tShinyStarSpriteId != 0xFF)
+        {
+            DestroySprite(&gSprites[task->tShinyStarSpriteId]);
+            FreeSpriteTilesByTag(GFXTAG_SHINY_STAR_PREVIEW);
+            FreeSpritePaletteByTag(PALTAG_SHINY_STAR_PREVIEW);
+        }
         task->tState++;
         break;
     case 3:
@@ -985,8 +1040,71 @@ bool8 ScriptMenu_ShowPokemonPic(u16 species, u8 x, u8 y)
         gTasks[taskId].tState = 0;
         gTasks[taskId].tMonSpecies = species;
         gTasks[taskId].tMonSpriteId = spriteId;
+        gTasks[taskId].tShinyStarSpriteId = 0xFF; // No shiny star for normal pokemon
         gSprites[spriteId].callback = SpriteCallbackDummy;
         gSprites[spriteId].oam.priority = 0;
+        SetStandardWindowBorderStyle(gTasks[taskId].tWindowId, TRUE);
+        ScheduleBgCopyTilemapToVram(0);
+        return TRUE;
+    }
+}
+
+bool8 ScriptMenu_ShowShinyPokemonPic(u16 species, u8 x, u8 y)
+{
+    u8 taskId;
+    u8 spriteId;
+    u8 shinyStarSpriteId;
+    void *gfxBuffer;
+    struct SpriteSheet sheet;
+    struct SpritePalette pal;
+
+    if (FindTaskIdByFunc(Task_PokemonPicWindow) != TASK_NONE)
+    {
+        return FALSE;
+    }
+    else
+    {
+        spriteId = CreateShinyMonSprite_PicBox(species, x * 8 + 40, y * 8 + 40, 0);
+        taskId = CreateTask(Task_PokemonPicWindow, 0x50);
+        gTasks[taskId].tWindowId = CreateWindowFromRect(x, y, 8, 8);
+        gTasks[taskId].tState = 0;
+        gTasks[taskId].tMonSpecies = species;
+        gTasks[taskId].tMonSpriteId = spriteId;
+        gSprites[spriteId].callback = SpriteCallbackDummy;
+        gSprites[spriteId].oam.priority = 0;
+
+        // Load and create shiny star sprite
+        gfxBuffer = Alloc(0x20 * 2);
+        if (gfxBuffer != NULL)
+        {
+            LZ77UnCompWram(sShinyStarTiles, gfxBuffer);
+            
+            sheet.data = gfxBuffer;
+            sheet.size = 0x20 * 2;
+            sheet.tag = GFXTAG_SHINY_STAR_PREVIEW;
+            
+            pal.data = sShinyStarPal;
+            pal.tag = PALTAG_SHINY_STAR_PREVIEW;
+            
+            LoadSpriteSheet(&sheet);
+            LoadSpritePalette(&pal);
+            Free(gfxBuffer);
+            
+            // Position shiny star at upper right corner of window
+            // Window is at (x, y) in tiles, each tile is 8 pixels
+            // Window is 8 tiles wide (64 pixels), so upper right is at x + 64 - 4 (center of 8px star)
+            shinyStarSpriteId = CreateSprite(&sSpriteTemplate_ShinyStarIcon, 
+                                            (x * 8) + 69,  // Upper right corner (64 - 4 for sprite center)
+                                            (y * 8) + 12,   // Top edge + 4 for sprite center
+                                            0);
+            gSprites[shinyStarSpriteId].oam.priority = 0;
+            gTasks[taskId].tShinyStarSpriteId = shinyStarSpriteId;
+        }
+        else
+        {
+            gTasks[taskId].tShinyStarSpriteId = 0xFF; // Failed to allocate
+        }
+
         SetStandardWindowBorderStyle(gTasks[taskId].tWindowId, TRUE);
         ScheduleBgCopyTilemapToVram(0);
         return TRUE;


### PR DESCRIPTION
- Added ScriptMenu_ShowShinyPokemonPic and CreateShinyMonSprite_PicBox rather than adding a shininess parameter to the existing functions
- Made "GetShinyOdds" non-static for use outside of pokemon.h
- Added logic to ScrCmd_showmonpic to check if a given starter preview has been checked yet, and if not roll for shininess with the same logic as CreateBoxMon
- Added logic to NewBarkTown_Lab_EventScript_ChoseStarter to guarantee that the given mon's shininess matches its preview
- Added a bunch of stuff from SkeletonKey to script_menu.c to show the shiny star on shiny previews (for randomized starters with ambiguous shinies)