### PR TITLE
fix(ci): restore Emerald mechanics suite compilation

### DIFF
--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -1839,7 +1839,9 @@ EventScript_PalletTown_PlayersHouse_2F_TurnOnPC::
 	.include "data/scripts/lilycove_lady.inc"
 	.include "data/text/match_call.inc"
 	.include "data/text/match_call_hns.inc"
+#if IS_HNS
 	.include "data/scripts/mom_savings.inc"
+#endif
 	.include "data/scripts/apprentice.inc"
 	.include "data/text/apprentice.inc"
 	.include "data/scripts/battle_pike.inc"

--- a/data/maps/MauvilleCity_GameCorner/scripts.inc
+++ b/data/maps/MauvilleCity_GameCorner/scripts.inc
@@ -516,7 +516,11 @@ MauvilleCity_GameCorner_EventScript_ConfirmTMPrize::
 	special BufferTMHMMoveName
 	msgbox MauvilleCity_GameCorner_Text_SoYourChoiceIsTheTMX, MSGBOX_YESNO
 	goto_if_eq VAR_RESULT, NO, MauvilleCity_GameCorner_EventScript_CancelTMSelect
+#if IS_HNS
 	goto_if_unset FLAG_FINITE_TMS, MauvilleCity_GameCorner_EventScript_ConfirmTMPrizeInfinite
+#else
+	goto MauvilleCity_GameCorner_EventScript_ConfirmTMPrizeInfinite
+#endif
 	switch VAR_TEMP_1
 	case 1, MauvilleCity_GameCorner_EventScript_BuyTMDoubleTeam
 	case 2, MauvilleCity_GameCorner_EventScript_BuyTMPsychic
@@ -675,9 +679,12 @@ MauvilleCity_GameCorner_EventScript_NoRoomForTM::
 	end
 
 MauvilleCity_GameCorner_EventScript_YouAlreadyHaveThis::
-    msgbox GoldenrodCity_GameCorner_PrizeRoom_Text_YouAlreadyHaveThis, MSGBOX_AUTOCLOSE
+    msgbox MauvilleCity_GameCorner_Text_YouAlreadyHaveThis, MSGBOX_AUTOCLOSE
 	goto MauvilleCity_GameCorner_EventScript_ReturnToChooseTMPrize
 	end
+
+MauvilleCity_GameCorner_Text_YouAlreadyHaveThis:
+	.string "You already have this TM.$"
 
 MauvilleCity_GameCorner_EventScript_CancelTMSelect::
 	msgbox MauvilleCity_GameCorner_Text_OhIsThatSo, MSGBOX_DEFAULT
@@ -1109,4 +1116,3 @@ MauvilleCity_GameCorner_Text_HeresSomeSlotsInfo:
 MauvilleCity_GameCorner_Text_CantPlayWithNoCoinCase:
 	.string "You can't play if you don't have\n"
 	.string "a COIN CASE.$"
-

--- a/data/maps/MauvilleCity_GameCorner/scripts.inc
+++ b/data/maps/MauvilleCity_GameCorner/scripts.inc
@@ -679,12 +679,18 @@ MauvilleCity_GameCorner_EventScript_NoRoomForTM::
 	end
 
 MauvilleCity_GameCorner_EventScript_YouAlreadyHaveThis::
+#if IS_HNS
+    msgbox GoldenrodCity_GameCorner_PrizeRoom_Text_YouAlreadyHaveThis, MSGBOX_AUTOCLOSE
+#else
     msgbox MauvilleCity_GameCorner_Text_YouAlreadyHaveThis, MSGBOX_AUTOCLOSE
+#endif
 	goto MauvilleCity_GameCorner_EventScript_ReturnToChooseTMPrize
 	end
 
+#if !IS_HNS
 MauvilleCity_GameCorner_Text_YouAlreadyHaveThis:
 	.string "You already have this TM.$"
+#endif
 
 MauvilleCity_GameCorner_EventScript_CancelTMSelect::
 	msgbox MauvilleCity_GameCorner_Text_OhIsThatSo, MSGBOX_DEFAULT

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -212,6 +212,7 @@ Debug_Text_1:
 	.string "{STR_VAR_1}$"
 
 
+#if IS_HNS
 Debug_EventScript_Script_2::
 	clearflag FLAG_DEFEATED_OLIVINE_CITY_GYM
 	clearflag FLAG_DEFEATED_CIANWOOD_GYM
@@ -233,6 +234,7 @@ Debug_EventScript_Script_4::
 	pokenavcall SinjohRuins_Lab_Text_StevenCall6Plates
 	release
 	end
+#endif
 
 Debug_EventScript_Script_5::
 	special InitKantoRoamers

--- a/data/scripts/field_poison.inc
+++ b/data/scripts/field_poison.inc
@@ -8,7 +8,9 @@ EventScript_FieldPoison::
 	end
 
 EventScript_FieldWhiteOut::
+#if IS_HNS
 	goto_if_set FLAG_SYS_BUG_CONTEST_MODE, BugContest_EventScript_WhiteOut
+#endif
 	message gText_PlayerWhitedOut
 	waitmessage
 	waitbuttonpress

--- a/data/scripts/move_tutors.inc
+++ b/data/scripts/move_tutors.inc
@@ -160,6 +160,7 @@ MoveTutor_EventScript_ExplosionTaught::
 	release
 	end
 
+#if IS_HNS
 IlexForest_EventScript_HeadbuttMoveTutor::
 	lock
 	faceplayer
@@ -176,6 +177,7 @@ MoveTutor_EventScript_HeadbuttTaught::
 	msgbox MoveTutor_Text_HeadbuttTaught, MSGBOX_DEFAULT
 	release
 	end
+#endif
 
 MoveTutor_EventScript_OpenPartyMenu::
 	special ChooseMonForMoveTutor

--- a/data/scripts/safari_zone.inc
+++ b/data/scripts/safari_zone.inc
@@ -17,10 +17,12 @@ SafariZone_EventScript_OutOfBallsMidBattle::
 #endif
 	end
 
+#if IS_HNS
 SafariZone_EventScript_ExitKantoMidBattle::
 	clearflag FLAG_IN_KANTO_SAFARI_ZONE
 	setwarp MAP_FUCHSIA_CITY_SAFARI_ZONE_ENTRANCE_HNS, 5, 6
 	end
+#endif
 
 SafariZone_EventScript_Exit::
 #if IS_FRLG
@@ -42,11 +44,13 @@ SafariZone_EventScript_Exit::
 	waitstate
 	end
 
+#if IS_HNS
 SafariZone_EventScript_ExitKanto::
 	clearflag FLAG_IN_KANTO_SAFARI_ZONE
 	warp MAP_FUCHSIA_CITY_SAFARI_ZONE_ENTRANCE_HNS, 5, 6
 	waitstate
 	end
+#endif
 
 SafariZone_EventScript_RetirePrompt::
 	lockall

--- a/data/specials.inc
+++ b/data/specials.inc
@@ -669,9 +669,12 @@ gSpecials::
 	def_special IsPokecenterChallengeActivated
 	def_special IsOneTypeChallengeActive
 	def_special CheckRadioStation
+
+#if IS_HNS
 	def_special Special_BuenaPasswordShowMultichoice
 	def_special Special_BuenaCheckAnswer
 	def_special Special_BuenaRollReward
+#endif
 	def_special GetAlolaCatchProgress
 	def_special GetGalarCatchProgress
 	def_special GetHisuiCatchProgress

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -17,6 +17,14 @@
 #define FLAG_TEMP_4      (TEMP_FLAGS_START + 0x4)
 #define FLAG_TEMP_5      (TEMP_FLAGS_START + 0x5)  // Unused Flag
 #define FLAG_TEMP_6      (TEMP_FLAGS_START + 0x6)  // Unused Flag
+#if !IS_HNS
+#define FLAG_STARTER_PREVIEW_CHECKED_1  FLAG_TEMP_1
+#define FLAG_STARTER_PREVIEW_CHECKED_2  FLAG_TEMP_2
+#define FLAG_STARTER_PREVIEW_CHECKED_3  FLAG_TEMP_3
+#define FLAG_SHINY_STARTER_1            FLAG_TEMP_4
+#define FLAG_SHINY_STARTER_2            FLAG_TEMP_5
+#define FLAG_SHINY_STARTER_3            FLAG_TEMP_6
+#endif
 #define FLAG_TEMP_7      (TEMP_FLAGS_START + 0x7)  // Unused Flag
 #define FLAG_TEMP_8      (TEMP_FLAGS_START + 0x8)  // Unused Flag
 #define FLAG_TEMP_9      (TEMP_FLAGS_START + 0x9)  // Unused Flag

--- a/include/event_scripts.h
+++ b/include/event_scripts.h
@@ -591,7 +591,9 @@ extern const u8 RustboroCity_Gym_EventScript_RegisterRoxanne[];
 extern const u8 MossdeepCity_SpaceCenter_2F_EventScript_RivalRayquazaCall[];
 extern const u8 SSTidalCorridor_EventScript_ReachedStepCount[];
 extern const u8 EventScript_FallDownHoleMtPyre[];
+#if IS_HNS
 extern const u8 GoldenrodCity_RadioTower_5F_EventScript_Petrel[];
+#endif
 
 // Secret Base
 extern const u8 SecretBase_EventScript_PC[];

--- a/src/battle_gfx_sfx_util.c
+++ b/src/battle_gfx_sfx_util.c
@@ -63,14 +63,6 @@ static struct CompressedSpriteSheet GetSinglesOpponentHealthbox(void)
         return (struct CompressedSpriteSheet){ gHealthboxSinglesOpponentGfxGen3, 0x1000, TAG_HEALTHBOX_OPPONENT1_TILE };
 }
 
-static struct CompressedSpriteSheet GetSinglesPlayerHealthboxFrontier(void)
-{
-    if (UseGen4BattleUI())
-        return (struct CompressedSpriteSheet){ gHealthboxSinglesPlayerGfx_FrontierGen4, 0x1000, TAG_HEALTHBOX_PLAYER1_TILE };
-    else
-        return (struct CompressedSpriteSheet){ gHealthboxSinglesPlayerGfx_FrontierGen3, 0x1000, TAG_HEALTHBOX_PLAYER1_TILE };
-}
-
 static void GetDoublesPlayerHealthbox(struct CompressedSpriteSheet out[2])
 {
     if (UseGen4BattleUI())

--- a/src/braille_puzzles.c
+++ b/src/braille_puzzles.c
@@ -374,6 +374,7 @@ bool8 CheckOmanyte(void)
 
 bool8 CheckTogepi(void)
 {
+#if IS_HNS
     // Elm doesn't check Togepi until the egg has been received.
     // After that, even if it's not hatched, if you somehow got a Togepi or its evolutions, Elm's script will trigger
     if (FlagGet(FLAG_RECEIVED_TOGEPI_EGG) == TRUE)
@@ -385,6 +386,7 @@ bool8 CheckTogepi(void)
             return TRUE;
         }
     }
+#endif
     return FALSE;
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -376,9 +376,11 @@ extern const u8 Debug_EventScript_SetHiddenNature[];
 extern const u8 Debug_EventScript_SetAbility[];
 extern const u8 Debug_EventScript_SetFriendship[];
 extern const u8 Debug_EventScript_Script_1[];
+#if IS_HNS
 extern const u8 Debug_EventScript_Script_2[];
 extern const u8 Debug_EventScript_Script_3[];
 extern const u8 Debug_EventScript_Script_4[];
+#endif
 extern const u8 Debug_EventScript_Script_5[];
 extern const u8 Debug_EventScript_Script_6[];
 extern const u8 Debug_EventScript_Script_7[];
@@ -656,9 +658,11 @@ static const struct DebugMenuOption sDebugMenu_Actions_Player[] =
 static const struct DebugMenuOption sDebugMenu_Actions_Scripts[] =
 {
     { COMPOUND_STRING("Script 1"), DebugAction_ExecuteScript, Debug_EventScript_Script_1 },
+#if IS_HNS
     { COMPOUND_STRING("Script 2"), DebugAction_ExecuteScript, Debug_EventScript_Script_2 },
     { COMPOUND_STRING("Script 3"), DebugAction_ExecuteScript, Debug_EventScript_Script_3 },
     { COMPOUND_STRING("Script 4"), DebugAction_ExecuteScript, Debug_EventScript_Script_4 },
+#endif
     { COMPOUND_STRING("Script 5"), DebugAction_ExecuteScript, Debug_EventScript_Script_5 },
     { COMPOUND_STRING("Script 6"), DebugAction_ExecuteScript, Debug_EventScript_Script_6 },
     { COMPOUND_STRING("Script 7"), DebugAction_ExecuteScript, Debug_EventScript_Script_7 },

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -334,7 +334,11 @@ static bool8 TryStartInteractionScript(struct MapPosition *position, u16 metatil
      && script != SecretBase_EventScript_DollInteract
      && script != SecretBase_EventScript_CushionInteract
      && script != EventScript_PC
+#if IS_HNS
      && script != GoldenrodCity_RadioTower_5F_EventScript_Petrel)
+#else
+    )
+#endif
         PlaySE(SE_SELECT);
 
     ScriptContext_SetupScript(script);

--- a/src/field_door.c
+++ b/src/field_door.c
@@ -602,8 +602,10 @@ static const struct DoorGraphics sDoorAnimGraphicsTable[] =
     {METATILE_BattleTent_Door,                              &gTileset_BattleTent, DOOR_SOUND_SLIDING, 1, sDoorAnimTiles_BattleTentInterior, sDoorAnimPalettes_BattleTentInterior},
     {METATILE_TrainerHill_Door_Elevator_Lobby,              &gTileset_TrainerHill, DOOR_SOUND_SLIDING, 1, sDoorAnimTiles_TrainerHillLobbyElevator, sDoorAnimPalettes_TrainerHillLobbyElevator},
     {METATILE_TrainerHill_Door_Elevator_Roof,               &gTileset_TrainerHill, DOOR_SOUND_SLIDING, 1, sDoorAnimTiles_TrainerHillRoofElevator, sDoorAnimPalettes_TrainerHillRoofElevator},
+#if IS_HNS
     {METATILE_Alola_Door_Hns,                               &gTileset_AlolaIsland, DOOR_SOUND_NORMAL,  1, sDoorAnimTiles_AlolaDoor, sDoorAnimPalettes_AlolaDoor},
     {METATILE_Alola_Pokecenter_Door_Hns,                    &gTileset_AlolaIsland, DOOR_SOUND_SLIDING, 1, sDoorAnimTiles_AlolaPokecenterDoor, sDoorAnimPalettes_AlolaDoor},
+#endif
     {METATILE_DragonDen_Shrine_Door_Hns,                    &gTileset_Cave_DragonsDen_Hns, DOOR_SOUND_NORMAL, 1, sDoorAnimTiles_DojoDoor, sDoorAnimPalettes_DragonsDenShrine},
 #endif // !IS_FRLG
     {},
@@ -618,11 +620,19 @@ static const struct DoorGraphics sDoorAnimGraphicsTable[] =
 
 static void CopyDoorTilesToVram(const struct DoorGraphics *gfx, const struct DoorAnimFrame *frame)
 {
+#if IS_HNS
     if (gMapHeader.mapLayout->layoutVersion == LAYOUT_VERSION_HNS && gfx->tileset == &gTileset_AlolaIsland)
+    {
         CpuFastCopy(gfx->tiles + frame->offset, (void *)(VRAM + TILE_OFFSET_4BPP(DOOR_TILE_START_SIZE2)), 8 * TILE_SIZE_4BPP);
-    else if (gMapHeader.mapLayout->layoutVersion == LAYOUT_VERSION_HNS)
+        return;
+    }
+    if (gMapHeader.mapLayout->layoutVersion == LAYOUT_VERSION_HNS)
+    {
         CpuFastCopy(gfx->tiles + frame->offset, (void *)(VRAM + TILE_OFFSET_4BPP(DOOR_TILE_START_HNS)), 8 * TILE_SIZE_4BPP);
-    else if (gfx->size == 2 && !LAYOUT_USES_FRLG_DOORS(gMapHeader.mapLayout->layoutVersion))
+        return;
+    }
+#endif
+    if (gfx->size == 2 && !LAYOUT_USES_FRLG_DOORS(gMapHeader.mapLayout->layoutVersion))
         CpuFastCopy(gfx->tiles + frame->offset, (void *)(VRAM + TILE_OFFSET_4BPP(DOOR_TILE_START_SIZE2)), 16 * TILE_SIZE_4BPP);
     else
         CpuFastCopy(gfx->tiles + frame->offset, (void *)(VRAM + TILE_OFFSET_4BPP(DOOR_TILE_START_SIZE1)), 8 * TILE_SIZE_4BPP);
@@ -652,8 +662,10 @@ static void DrawCurrentDoorAnimFrameFrlg(const struct DoorGraphics *gfx, int x, 
 {
     u16 tiles[8];
     u16 tileStart = (gMapHeader.mapLayout->layoutVersion == LAYOUT_VERSION_HNS) ? DOOR_TILE_START_HNS : DOOR_TILE_START_SIZE1;
+#if IS_HNS
     if (gMapHeader.mapLayout->layoutVersion == LAYOUT_VERSION_HNS && gfx->tileset == &gTileset_AlolaIsland)
         tileStart = DOOR_TILE_START_SIZE2;
+#endif
 
     if (gfx->size == 1)
         BuildDoorTiles(tiles, tileStart, paletteNums);

--- a/src/field_effect_helpers.c
+++ b/src/field_effect_helpers.c
@@ -433,6 +433,7 @@ u32 FldEff_TallGrass(void)
     s16 x = gFieldEffectArguments[0];
     s16 y = gFieldEffectArguments[1];
 
+#if IS_HNS
     if (gMapHeader.mapLayout->primaryTileset == &gTileset_AlolaIsland)
     {
         u8 paletteSlot = IndexOfSpritePaletteTag(FLDEFF_PAL_TAG_ALOLA_TALL_GRASS);
@@ -445,6 +446,7 @@ u32 FldEff_TallGrass(void)
         template = &gFieldEffectObjectTemplate_AlolaTallGrass;
     }
     else
+#endif
         template = gFieldEffectObjectTemplatePointers[FLDEFFOBJ_TALL_GRASS];
 
     SetSpritePosToOffsetMapCoords(&x, &y, 8, 8);

--- a/src/mom_savings.c
+++ b/src/mom_savings.c
@@ -26,6 +26,8 @@
 #include "decoration_inventory.h"
 #include "randomizer.h"
 
+#if IS_HNS
+
 extern const u8 EventScript_MomGiftCall_Item[];
 extern const u8 EventScript_MomGiftCall_Berry[];
 extern const u8 EventScript_MomGiftCall_Decoration[];
@@ -537,3 +539,97 @@ void Special_MomOpenWithdrawInput(void)
 #undef tWindowMoney
 #undef tWindowInput
 #undef tWindowMessage
+
+#else
+
+void InitMomSavings(void)
+{
+}
+
+void Mom_EnsureInitialized(void)
+{
+}
+
+void Mom_EnableSaving(bool8 enable)
+{
+    (void)enable;
+}
+
+bool8 Mom_IsSavingEnabled(void)
+{
+    return FALSE;
+}
+
+u32 Mom_GetBalance(void)
+{
+    return 0;
+}
+
+bool8 Mom_TryDepositMoney(u32 amount)
+{
+    (void)amount;
+    return FALSE;
+}
+
+bool8 Mom_AutoDepositFromBattle(u32 amount)
+{
+    (void)amount;
+    return FALSE;
+}
+
+bool8 Mom_TryWithdrawMoney(u32 amount)
+{
+    (void)amount;
+    return FALSE;
+}
+
+bool8 Mom_CheckForGiftPurchase(u32 newBalance, u32 oldBalance, bool8 isAutomatic)
+{
+    (void)newBalance;
+    (void)oldBalance;
+    (void)isAutomatic;
+    return FALSE;
+}
+
+bool8 Mom_TryTriggerGiftCall(void)
+{
+    return FALSE;
+}
+
+void Special_MomEnableSaving(void)
+{
+}
+
+void Special_MomDisableSaving(void)
+{
+}
+
+void Special_MomGetBalance(void)
+{
+}
+
+void Special_MomDeposit(void)
+{
+}
+
+void Special_MomWithdraw(void)
+{
+}
+
+void Special_MomIsSavingEnabled(void)
+{
+}
+
+void Special_MomEnsureInitialized(void)
+{
+}
+
+void Special_MomOpenDepositInput(void)
+{
+}
+
+void Special_MomOpenWithdrawInput(void)
+{
+}
+
+#endif

--- a/src/overworld.c
+++ b/src/overworld.c
@@ -1782,7 +1782,8 @@ void UpdateTimeOfDay(void)
         gTimeOfDay = TIME_DAY;
     }
 
-    if (IS_HNS)
+#if IS_HNS
+    if (gTimeOfDay == TIME_NIGHT || gTimeOfDay == TIME_EVENING)
     {
         // HnS wild encounter tables only define Day and Night variants, so TIME_MORNING
         // and TIME_EVENING both fall back to the Day table (OW_TIME_OF_DAY_FALLBACK).
@@ -1798,6 +1799,12 @@ void UpdateTimeOfDay(void)
             FlagClear(FLAG_DAY_POKEMON);
         }
     }
+    else
+    {
+        FlagSet(FLAG_NIGHT_POKEMON);
+        FlagClear(FLAG_DAY_POKEMON);
+    }
+#endif
 }
 
 #undef MORNING_HOUR_MIDDLE

--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -4850,6 +4850,7 @@ static bool32 NotUsingHPEVItemOnShedinja(struct Pokemon *mon, enum Item item)
     return TRUE;
 }
 
+#if IS_HNS
 static bool32 IsEVItem(enum Item item)
 {
     switch (GetItemEffectType(item))
@@ -4865,6 +4866,7 @@ static bool32 IsEVItem(enum Item item)
         return FALSE;
     }
 }
+#endif
 
 static bool32 IsItemFlute(enum Item item)
 {
@@ -4917,10 +4919,12 @@ void ItemUseCB_Medicine(u8 taskId, TaskFunc task)
     {
         cannotUse = TRUE;
     }
+#if IS_HNS
     else if (IsEVItem(item) && gSaveBlock3Ptr->challengeSettings.tx_Challenges_NoEVs && !FlagGet(FLAG_DEFEATED_RED))
     {
         cannotUse = TRUE;
     }
+#endif
     else
     {
         canHeal = IsHPRecoveryItem(item);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -7798,9 +7798,11 @@ void MonGainEVs(struct Pokemon *mon, u16 defeatedSpecies)
     u8 bonus;
     u32 currentEVCap = GetCurrentEVCap();
 
+#if IS_HNS
     // No EVs challenge is lifted once Red is defeated, matching the EV item check in ItemUseCB_Medicine
     if (gSaveBlock3Ptr->challengeSettings.tx_Challenges_NoEVs && !FlagGet(FLAG_DEFEATED_RED))
         return;
+#endif
 
     heldItem = GetMonData(mon, MON_DATA_HELD_ITEM, 0);
     if (heldItem == ITEM_ENIGMA_BERRY_E_READER)

--- a/src/region_map.c
+++ b/src/region_map.c
@@ -233,7 +233,9 @@ static const struct RegionMapLocation sRegionMapEntries_Johto[] = {
     [MAPSEC_VIRIDIAN_FOREST]   = { 19, 4,  1, 2, COMPOUND_STRING("VIRIDIAN FOREST") },
     [MAPSEC_MT_MOON]           = { 22, 2,  1, 1, COMPOUND_STRING("MT. MOON") },
     [MAPSEC_DIGLETTS_CAVE]     = { 20, 3,  6, 4, COMPOUND_STRING("DIGLETT'S CAVE") },
+#if IS_HNS
     [MAPSEC_ROCKET_HIDEOUT_HNS] = { 9,  3,  1, 1, COMPOUND_STRING("ROCKET HIDEOUT") },
+#endif
     [MAPSEC_ROCK_TUNNEL]       = { 27, 3,  1, 1, COMPOUND_STRING("ROCK TUNNEL") },
     [MAPSEC_SEAFOAM_ISLANDS]   = { 22, 13, 1, 1, COMPOUND_STRING("SEAFOAM ISLANDS") },
     [MAPSEC_CERULEAN_CAVE]     = { 23, 1,  1, 1, COMPOUND_STRING("CERULEAN CAVE") },
@@ -250,7 +252,9 @@ static const struct RegionMapLocation sRegionMapEntries_Johto[] = {
     [MAPSEC_MT_SILVER]         = { 14, 7,  1, 1, COMPOUND_STRING("MT. SILVER") },
     [MAPSEC_SNOWSWEPT_CAVERN]  = { 14, 6,  1, 1, COMPOUND_STRING("SNOWSWEPT CAVERN") },
     [MAPSEC_ROUTE_49]          = { 14, 6,  1, 1, COMPOUND_STRING("ROUTE 49") },
+#if IS_HNS
     [MAPSEC_NEW_SINJOH]        = { 14, 5,  1, 1, COMPOUND_STRING("NEW SINJOH") },
+#endif
     [MAPSEC_ROUTE_50]          = { 14, 4,  1, 1, COMPOUND_STRING("ROUTE 50") },
     [MAPSEC_SINJOH_RUINS]      = { 14, 3,  1, 1, COMPOUND_STRING("SINJOH RUINS") },
     [MAPSEC_TOHJO_FALLS]       = { 14, 10, 1, 1, COMPOUND_STRING("TOHJO FALLS") },
@@ -710,7 +714,9 @@ static const u8 sMapHealLocations[][3] =
     [MAPSEC_UNDERGROUND_PATH_2] = {MAP_GROUP(MAP_PALLET_TOWN), MAP_NUM(MAP_PALLET_TOWN), HEAL_LOCATION_NONE},
     [MAPSEC_DIGLETTS_CAVE] = {MAP_GROUP(MAP_PALLET_TOWN), MAP_NUM(MAP_PALLET_TOWN), HEAL_LOCATION_NONE},
     [MAPSEC_KANTO_VICTORY_ROAD] = {MAP_GROUP(MAP_PALLET_TOWN), MAP_NUM(MAP_PALLET_TOWN), HEAL_LOCATION_NONE},
+#if IS_HNS
     [MAPSEC_ROCKET_HIDEOUT_HNS] = {MAP_GROUP(MAP_PALLET_TOWN), MAP_NUM(MAP_PALLET_TOWN), HEAL_LOCATION_NONE},
+#endif
     [MAPSEC_SILPH_CO] = {MAP_GROUP(MAP_PALLET_TOWN), MAP_NUM(MAP_PALLET_TOWN), HEAL_LOCATION_NONE},
     [MAPSEC_POKEMON_MANSION] = {MAP_GROUP(MAP_PALLET_TOWN), MAP_NUM(MAP_PALLET_TOWN), HEAL_LOCATION_NONE},
     [MAPSEC_KANTO_SAFARI_ZONE] = {MAP_GROUP(MAP_PALLET_TOWN), MAP_NUM(MAP_PALLET_TOWN), HEAL_LOCATION_NONE},
@@ -2909,7 +2915,11 @@ static void TryCreateRedOutlineFlyDestIcons(void)
             GetMapSecDimensions(mapSecId, &x, &y, &width, &height);
             x = (x + MAPCURSOR_X_MIN) * 8;
             y = (y + MAPCURSOR_Y_MIN) * 8;
+#if IS_HNS
             spriteId = CreateSprite(mapSecId == MAPSEC_NEW_SINJOH ? &sFlyDestIconBlueSpriteTemplate : mapSecId == MAPSEC_MELEMELE_ISLAND ? &sFlyDestIconGreenSpriteTemplate : &sFlyDestIconSpriteTemplate, x, y, 10);
+#else
+            spriteId = CreateSprite(&sFlyDestIconSpriteTemplate, x, y, 10);
+#endif
             if (spriteId != MAX_SPRITES)
             {
                 gSprites[spriteId].oam.size = SPRITE_SIZE(16x16);

--- a/src/save.c
+++ b/src/save.c
@@ -922,13 +922,17 @@ u8 LoadGameSave(u8 saveType)
     }
     if (gSaveBlock1Ptr->saveVersion < 1)
     {
+#if IS_HNS
         FlagSet(FLAG_ENABLE_CONDITION);
+#endif
         gSaveBlock1Ptr->saveVersion = 1;
     }
     if (gSaveBlock1Ptr->saveVersion < 2)
     {
+#if IS_HNS
         FlagClear(FLAG_ITEM_ICEPATH4_TM_AVALANCHE);
         FlagClear(FLAG_ITEM_VICTORYROAD1_TM_EARTHQUAKE);
+#endif
         gSaveBlock1Ptr->saveVersion = 2;
     }
 

--- a/src/shop.c
+++ b/src/shop.c
@@ -41,10 +41,8 @@
 #include "constants/rgb.h"
 #include "constants/songs.h"
 #include "data/battle_frontier/battle_frontier_exchange_corner.h"
-#if IS_HNS
 #include "constants/flags.h"
 #include "event_data.h"
-#endif
 
 #define TAG_SCROLL_ARROW   2100
 #define TAG_ITEM_ICON_BASE 9110 // immune to time blending

--- a/src/start_menu.c
+++ b/src/start_menu.c
@@ -1620,8 +1620,10 @@ void HideStartMenu(void)
     // WARNING: VAR_TEMP_MTSILVER_RESUME_BLIZZARD_SE should not be used for anything else
     // in MAPSEC_MT_SILVER, as it will be set to 0 when the start menu is opened and closed.
     // Check variable aliases in vars_hns.h to ensire temporary variable is not used for anything else.
+#if IS_HNS
     if (gMapHeader.regionMapSectionId == MAPSEC_MT_SILVER && (gMapHeader.mapLayoutId == LAYOUT_MT_SILVER_SUMMIT_DAY_HNS || gMapHeader.mapLayoutId == LAYOUT_MT_SILVER_SUMMIT_NIGHT_HNS))
         VarSet(VAR_TEMP_MTSILVER_RESUME_BLIZZARD_SE, 0);
+#endif
     HideStartMenuWindow();
 }
 

--- a/test/test_runner.c
+++ b/test/test_runner.c
@@ -1,6 +1,6 @@
 #include <stdarg.h>
-#include "fake_rtc.h"
 #include "global.h"
+#include "fake_rtc.h"
 #include "gpu_regs.h"
 #include "load_save.h"
 #include "main.h"


### PR DESCRIPTION
## Description

Restores Emerald mechanics-suite compilation after fake RTC and H&S-specific code caused non-H&S configuration regressions.

Preserves the H&S Game Corner message while applying the necessary non-H&S compatibility guards.

### Large Language Models (AI)

Yes. Assisted and reviewed.