### PR TITLE
Pokemon now have a 50% chance of holding one of their evolutionary items

### DIFF
--- a/.github/agents/pokehns-rom-dev.agent.md
+++ b/.github/agents/pokehns-rom-dev.agent.md
@@ -1,0 +1,48 @@
+---
+name: Pokemon HnS ROM Dev Specialist
+description: Use when working on Pokemon HnS fan game ROM development, pokehns-expansion feature work, bug fixes, balancing, scripting, battle systems, data tables, graphics integration, map/event logic, or when comparing behavior with rh-hideout/pokeemerald-expansion and pret/pokeemerald.
+argument-hint: Describe the gameplay feature, bug, subsystem, or file area to investigate or change.
+tools: [read, search, edit, execute, web]
+user-invocable: true
+---
+You are a highly skilled software developer specializing in fan-based Pokemon ROM development for Pokemon HnS.
+
+You have strong practical familiarity with these codebases:
+- PokemonHnS-Development/pokehns-expansion (primary project)
+- rh-hideout/pokeemerald-expansion (feature and architecture reference)
+- pret/pokeemerald (baseline engine behavior reference)
+
+Your job is to answer technical questions about this repository and implement high-level game features safely and accurately.
+
+## Domain Scope
+- Core gameplay systems in C and assembly-adjacent integration points
+- Battle logic, abilities, moves, items, and species data behavior
+- Event scripting, map data, encounter setup, trainers, and progression logic
+- Graphics and asset pipeline touchpoints tied to gameplay features
+- Build, validation, and regression checks relevant to the changed subsystem
+
+## Tool Strategy
+- Prefer search and read tools first to map call paths and data flow before editing.
+- Use edit tools for focused, minimal patches that preserve project style and APIs.
+- Use execute tools to run targeted build or validation commands after changes.
+- Ask for user confirmation before any web lookup, and use web tools only when needed to verify upstream behavior, conventions, or docs.
+
+## Constraints
+- Do not invent project-specific behavior without grounding it in current repository code.
+- Do not make broad refactors unless explicitly requested.
+- Do not modify unrelated files during feature work.
+- Preserve gameplay compatibility expectations unless the request explicitly changes them.
+
+## Working Method
+1. Discover relevant code paths and data sources in the repository before proposing changes.
+2. Explain the likely implementation surface and risks in concise terms.
+3. Implement the smallest coherent patch set needed for the requested behavior.
+4. Run targeted verification (build/tests/checks) when feasible and report outcomes.
+5. Summarize changed files, gameplay impact, and any follow-up steps.
+
+## Output Format
+Return results in this order:
+1. What changed and why
+2. Exact files touched
+3. Validation performed and outcomes
+4. Remaining risks, assumptions, or follow-up options

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -8382,6 +8382,123 @@ static inline bool32 CanFirstMonBoostHeldItemRarity(void)
     return FALSE;
 }
 
+#define MAX_WILD_EVO_LINE_ITEMS_PER_SPECIES 16
+
+EWRAM_DATA static u16 sWildEvoTraversalQueue[NUM_SPECIES] = {0};
+EWRAM_DATA static bool8 sWildEvoTraversalVisited[NUM_SPECIES] = {FALSE};
+
+static bool32 AddUniqueEvolutionItem(enum Item item, enum Item *items, u16 *count)
+{
+    u16 i;
+
+    if (item == ITEM_NONE || *count >= MAX_WILD_EVO_LINE_ITEMS_PER_SPECIES)
+        return FALSE;
+
+    for (i = 0; i < *count; i++)
+    {
+        if (items[i] == item)
+            return FALSE;
+    }
+
+    items[(*count)++] = item;
+    return TRUE;
+}
+
+static void CollectEvolutionItemsFromEntry(const struct Evolution *evolution, enum Item *items, u16 *itemCount)
+{
+    u16 i;
+
+    if (evolution->method == EVO_ITEM)
+        AddUniqueEvolutionItem(evolution->param, items, itemCount);
+
+    for (i = 0; evolution->params != NULL && evolution->params[i].condition != CONDITIONS_END; i++)
+    {
+        switch (evolution->params[i].condition)
+        {
+        case IF_HOLD_ITEM:
+        case IF_BAG_ITEM_COUNT:
+            AddUniqueEvolutionItem(evolution->params[i].arg1, items, itemCount);
+            break;
+        }
+    }
+}
+
+static u16 GetBaseSpeciesForEvolutionLine(u16 species)
+{
+    u16 preEvo;
+    u16 safety = 0;
+
+    while ((preEvo = GetSpeciesPreEvolution(species)) != SPECIES_NONE)
+    {
+        species = preEvo;
+        if (++safety >= NUM_SPECIES)
+            break;
+    }
+
+    return species;
+}
+
+static u16 GetEvolutionItemsForSpeciesLine(u16 species, enum Item *items)
+{
+    u16 baseSpecies;
+    u16 itemCount = 0;
+    u16 head = 0;
+    u16 tail = 0;
+
+    species = SanitizeSpeciesId(species);
+    if (species == SPECIES_NONE)
+        return 0;
+
+    baseSpecies = GetBaseSpeciesForEvolutionLine(species);
+    if (baseSpecies == SPECIES_NONE)
+        return 0;
+
+    memset(sWildEvoTraversalVisited, FALSE, sizeof(sWildEvoTraversalVisited));
+    sWildEvoTraversalQueue[tail++] = baseSpecies;
+    sWildEvoTraversalVisited[baseSpecies] = TRUE;
+
+    while (head < tail)
+    {
+        u16 currentSpecies = sWildEvoTraversalQueue[head++];
+        const struct Evolution *evolutions = GetSpeciesEvolutions(currentSpecies);
+        u16 i;
+
+        for (i = 0; evolutions != NULL && evolutions[i].method != EVOLUTIONS_END; i++)
+        {
+            u16 targetSpecies = SanitizeSpeciesId(evolutions[i].targetSpecies);
+
+            CollectEvolutionItemsFromEntry(&evolutions[i], items, &itemCount);
+
+            if (targetSpecies == SPECIES_NONE || !IsSpeciesEnabled(targetSpecies) || sWildEvoTraversalVisited[targetSpecies])
+                continue;
+
+            sWildEvoTraversalQueue[tail++] = targetSpecies;
+            sWildEvoTraversalVisited[targetSpecies] = TRUE;
+        }
+    }
+
+    return itemCount;
+}
+
+static bool32 TrySetWildMonEvolutionLineHeldItem(struct Pokemon *mon)
+{
+    u16 species = SanitizeSpeciesId(GetMonData(mon, MON_DATA_SPECIES, 0));
+    enum Item items[MAX_WILD_EVO_LINE_ITEMS_PER_SPECIES] = {0};
+    u16 itemCount = GetEvolutionItemsForSpeciesLine(species, items);
+    enum Item item;
+
+    if (itemCount == 0)
+        return FALSE;
+
+    // Exactly 50% chance for species that have item-based evolutions in their line.
+    if ((Random() % 100) >= 50)
+        return FALSE;
+
+    item = items[Random() % itemCount];
+    SetMonData(mon, MON_DATA_HELD_ITEM, &item);
+    return TRUE;
+}
+
 void SetWildMonHeldItem(void)
 {
     if (!(gBattleTypeFlags & (BATTLE_TYPE_LEGENDARY | BATTLE_TYPE_TRAINER | BATTLE_TYPE_PYRAMID | BATTLE_TYPE_PIKE)))
@@ -8398,6 +8515,9 @@ void SetWildMonHeldItem(void)
         {
             if (GetMonData(&gEnemyParty[i], MON_DATA_HELD_ITEM) != ITEM_NONE)
                 continue; // prevent overwriting previously set item
+
+            if (TrySetWildMonEvolutionLineHeldItem(&gEnemyParty[i]))
+                continue;
 
             rnd = Random() % 100;
             species = GetMonData(&gEnemyParty[i], MON_DATA_SPECIES, 0);


### PR DESCRIPTION
Added a 50% chance for a Pokemon to be holding one of it's evolutionary items, if that Pokemon requires an evolutionary item at any point in it's evolutionary line. That 50% chance is broken down evenly across all potential evolutionary items across it's evolutionary line (i.e. Eevee's 50% is split three ways between the Fire Stone, Thunder Stone, and Water Stone). This is calculated at runtime and may cause some extra performance, though I have seen no latency. If the 50% check fails, the standard held item check will be used as a fallback. This code will fail if there is ever a Pokemon that has more than 16 evolutionary items in its ancestry. Let's hope, for everyone's sake, that never happens.
