### PR TITLE
Fixed typo in Alolan Dugtrio's pokedex description

### DIFF
--- a/src/data/pokemon/species_info/gen_1_families.h
+++ b/src/data/pokemon/species_info/gen_1_families.h
@@ -7381,7 +7381,7 @@ const struct SpeciesInfo gSpeciesInfoGen1[] =
         .description = COMPOUND_STRING(
             "Their beautiful, metallic whiskers create\n"
             "a sort of protective helmet on\n"
-            "heir heads, and they also function\n"
+            "their heads, and they also function\n"
             "as highly precise sensors."),
         .pokemonScale = 406,
         .pokemonOffset = 18,


### PR DESCRIPTION
Fixed typo in Alolan Dugtrio's pokedex description

## Description
Fixed a minor typo in Alolan Dugtrio's pokedex (changed "heir" to "their").

### Large Language Models (AI)
No LLM was used.

## Media
N/A

## Things to note in the release changelog:
Fixed minor typo in Alolan Dugtrio's pokedex entry

## Discord contact info
N/A

## Additional notes
I was looking through the code and happened upon this typo. Hopefully this is a simple fix that doesn't require me to go through the proper Discord channels (not a huge discord fan).

**Please don't add me to the credits for a simple typo fix.**